### PR TITLE
Upgrades and bug fixes

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -41,7 +41,7 @@ jobs:
           path: "ui"
 
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v3
 
       - name: Initialize
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Run pre-commit
         run: make run_pre_commit

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Initialize (one-time setup) with
 
 ```shell
 # NOTE: Populate the variables.
-CSP= IDENTIFIER= bash scripts/init.sh`.
+CSP= IDENTIFIER= bash scripts/init.sh.
 ```
 
 For local use, you can create symbolic links to the API and UI repository.

--- a/scripts/build_api.sh
+++ b/scripts/build_api.sh
@@ -4,15 +4,15 @@
 Build the API.
 
 Takes as inputs:
-* CSP: Cloud Service Provider. E.g., $(azure) or $(gcp).
+* CSP: Cloud Service Provider. E.g., azure or gcp.
 * IDENTIFIER: The identifier for the CSP. E.g., the subscription id for Azure or the project id for GCP.
 * REGISTRY_NAME: The name of the container registry.
 * REPOSITORY_NAME: The name of the repository.
 * IMAGE_NAME: The name of the image to be built. E.g., a git hash.
 
 Examples:
-* $(CSP=azure REGISTRY_NAME=myregistry REPOSITORY_NAME=myrepository IMAGE_NAME=ca20cdd bash scripts/build_api.sh).
-* $(CSP=gcp IDENTIFIER=1234 REGISTRY_NAME=europe-west1 REPOSITORY_NAME=myrepository IMAGE_NAME=ca20cdd bash scripts/build_api.sh).
+* CSP=azure REGISTRY_NAME=myregistry REPOSITORY_NAME=myrepository IMAGE_NAME=ca20cdd bash scripts/build_api.sh.
+* CSP=gcp IDENTIFIER=1234 REGISTRY_NAME=europe-west1 REPOSITORY_NAME=myrepository IMAGE_NAME=ca20cdd bash scripts/build_api.sh.
 "
 
 # Stop upon error and undefined variables.
@@ -35,6 +35,6 @@ elif [ "$CSP" = "gcp" ]; then
     docker tag api_amd "$REGISTRY_NAME-docker.pkg.dev/$IDENTIFIER/$REPOSITORY_NAME/api:$IMAGE_NAME"
     docker push "$REGISTRY_NAME-docker.pkg.dev/$IDENTIFIER/$REPOSITORY_NAME/api:$IMAGE_NAME"
 else
-    echo "Invalid parameter. Use 'Azure' or 'GCP'."
+    echo "Invalid parameter. Use 'azure' or 'gcp'."
     exit 1
 fi

--- a/scripts/build_ui.sh
+++ b/scripts/build_ui.sh
@@ -3,7 +3,7 @@
 : "
 Build the UI.
 
-Example: `bash scripts/build_ui.sh`.
+Example: bash scripts/build_ui.sh.
 "
 
 # Stop upon error and undefined variables.
@@ -16,5 +16,5 @@ set -eux
     bun run build
 
 )
-mv ui/dist/* api/ui/
+rsync -av --remove-source-files ui/dist/ api/ui/
 cp -R ui/public api/ui/

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -4,14 +4,14 @@
 Use Terraform to deploy the infrastructure.
 
 Takes as inputs:
-* CSP: Cloud Service Provider. E.g., `azure` or `gcp`.
+* CSP: Cloud Service Provider. E.g., azure or gcp.
 * IDENTIFIER: The identifier for the CSP. E.g., the subscription id for Azure or the project id for GCP.
 * REGISTRY_NAME: The name of the container registry.
 * REPOSITORY_NAME: The name of the repository.
 
 Examples:
-* `CSP=azure REGISTRY_NAME=myregistry REPOSITORY_NAME=myrepository bash scripts/deploy.sh`.
-* `CSP=gcp IDENTIFIER=1234 REGISTRY_NAME=europe-west1 REPOSITORY_NAME=myrepository bash scripts/deploy.sh`.
+* CSP=azure REGISTRY_NAME=myregistry REPOSITORY_NAME=myrepository bash scripts/deploy.sh.
+* CSP=gcp IDENTIFIER=1234 REGISTRY_NAME=europe-west1 REPOSITORY_NAME=myrepository bash scripts/deploy.sh.
 "
 
 # Stop upon error and undefined variables.

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -5,10 +5,10 @@ Initialize infrastructure deployments.
 Typically you only need to run this once.
 
 Takes as inputs:
-* CSP: Cloud Service Provider. E.g., `azure` or `gcp`.
+* CSP: Cloud Service Provider. E.g., azure or gcp.
 * IDENTIFIER: The identifier for the CSP. E.g., the subscription id for Azure or the project id for GCP.
 
-Example: `CSP=azure IDENTIFIER=1234 bash scripts/init.sh`.
+Example: CSP=azure IDENTIFIER=1234 bash scripts/init.sh.
 "
 
 if [ "$CSP" = "azure" ]; then
@@ -27,5 +27,5 @@ fi
 # Terraform initialization.
 (
   cd "terraform/$CSP" || exit
-  terraform init -backend-config="terraform/$CSP/backend.conf"
+  terraform init -upgrade -backend-config="backend.conf"
 )

--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -13,6 +13,7 @@ terraform {
 
 provider "azurerm" {
   features {}
+  subscription_id = var.subscription_id
 }
 
 data "azurerm_client_config" "current" {}
@@ -162,9 +163,10 @@ resource "azurerm_linux_web_app" "app_service" {
       docker_registry_username = azurerm_container_registry.container_registry.admin_username
       docker_registry_password = azurerm_container_registry.container_registry.admin_password
     }
-    ftps_state        = "FtpsOnly"
-    health_check_path = var.health_check_path
-    http2_enabled     = true
+    ftps_state                        = "FtpsOnly"
+    health_check_path                 = var.health_check_path
+    health_check_eviction_time_in_min = 5
+    http2_enabled                     = true
   }
 
   logs {

--- a/terraform/azure/variables.tf
+++ b/terraform/azure/variables.tf
@@ -1,4 +1,8 @@
 # General.
+variable "subscription_id" {
+  type        = string
+  description = "The Azure subscription ID."
+}
 
 variable "location" {
   type        = string


### PR DESCRIPTION
- Upgrade GitHub Action dependencies
- Remove `$()` syntax in examples since they may execute in bash environments
- Change from `mv` to `rsync -av --remove-source-files` in order to deploy multiple times in a row without cleaning up old files.
- Set `subscription_id = var.subscription_id` which is now a requirement in `hashicorp/azurerm > 4`
- Set `health_check_eviction_time_in_min` which is now a requirement in `hashicorp/azurerm > 4`
- Add `-upgrade` to Terraform init in case the source controlled lock file is not aligned with the terraform provider version. One may argue that this should not be included so happy to remove it if so. 